### PR TITLE
Add simple reply mechanism

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,18 @@
+Release Notes
+=============
+
+Version 0.0.3
+-------------
+
+Released 2017-07-27
+
+* Adds replying by returning from handle_message entrypoint
+
+
+Version 0.0.2
+-------------
+
+Released 2017-02-11
+
+* Initial release
+* Adds RTM extension

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Ondrej Kohout
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -140,3 +140,18 @@ to the entrypoint:
         @rtm.handle_message('^egg (?P<ham>\w+)')
         def on_egg(self, event, message, ham=None):
             pass
+
+Respond back to the channel by returning a string in the message handling
+entrypoint:
+
+.. code:: python
+
+    from nameko_slack import rtm
+
+    class Service:
+
+        name = 'some-service'
+
+        @rtm.handle_message
+        def sure(self, event, message):
+            return 'sure, {}'.format(message)

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ setup(
     ],
     extras_require={
         'dev': [
-            "coverage==4.3.4",
-            "flake8==3.2.1",
-            "pylint==1.6.4",
-            "pytest==3.0.5",
+            "coverage",
+            "flake8",
+            "pylint",
+            "pytest",
         ]
     },
     dependency_links=[],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='nameko-slack',
-    version='0.0.2',
+    version='0.0.3',
     description='Nameko extension for interaction with Slack APIs',
     author='Ondrej Kohout',
     author_email='ondrej.kohout@gmail.com',


### PR DESCRIPTION
Reply from the result of handle_message entrypoint.
Reply to the same channel as the one the message came from.