### PR TITLE
 fix dependencies fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="ondrej.kohout@gmail.com",
     url="http://github.com/iky/nameko-slack",
     packages=find_packages(exclude=["test", "test.*"]),
-    install_requires=["nameko>=2.7.0", "slackclient>=1.0.4"],
+    install_requires=["nameko>=2.7.0", "slackclient==1.0.4"],
     extras_require={
         "dev": ["coverage", "flake8", "isort", "pre-commit", "pylint", "pytest"]
     },

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="ondrej.kohout@gmail.com",
     url="http://github.com/iky/nameko-slack",
     packages=find_packages(exclude=["test", "test.*"]),
-    install_requires=["nameko>=2.7.0", "slackclient==1.3.1"],
+    install_requires=["nameko>=2.7.0", "slackclient>=1.0.4,<2"],
     extras_require={
         "dev": ["coverage", "flake8", "isort", "pre-commit", "pylint", "pytest"]
     },

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="ondrej.kohout@gmail.com",
     url="http://github.com/iky/nameko-slack",
     packages=find_packages(exclude=["test", "test.*"]),
-    install_requires=["nameko>=2.7.0", "slackclient==1.0.4"],
+    install_requires=["nameko>=2.7.0", "slackclient==1.3.1"],
     extras_require={
         "dev": ["coverage", "flake8", "isort", "pre-commit", "pylint", "pytest"]
     },


### PR DESCRIPTION
- set version of slackclient to 1.3.1

slackclient has released a new version(2.0.1), and it seems like has some api change, can we just lock the version of slackclient to 1.3.1 for now ?